### PR TITLE
Don't raise in `Tools`

### DIFF
--- a/src/xref2/compile.ml
+++ b/src/xref2/compile.ml
@@ -101,9 +101,14 @@ and class_type_expr env =
   | Signature s -> Signature (class_signature env s)
 
 and class_type env c =
+  let exception Compile_class_type in
   let open ClassType in
   let c' = Env.lookup_class_type c.id env in
-  let sg = Tools.class_signature_of_class_type env c' in
+  let sg =
+    match Tools.class_signature_of_class_type env c' with
+    | Some sg -> sg
+    | None -> raise Compile_class_type
+  in
   let expansion =
     Some
       (Lang_of.class_signature Lang_of.empty
@@ -138,9 +143,14 @@ and instance_variable env i =
   { i with type_ = type_expression env i.type_ }
 
 and class_ env c =
+  let exception Compile_class_ in
   let open Class in
   let c' = Env.lookup_class c.id env in
-  let sg = Tools.class_signature_of_class env c' in
+  let sg =
+    match Tools.class_signature_of_class env c' with
+    | Some sg -> sg
+    | None -> raise Compile_class_
+  in
   let expansion =
     Some
       (Lang_of.class_signature Lang_of.empty

--- a/src/xref2/compile.ml
+++ b/src/xref2/compile.ml
@@ -206,7 +206,6 @@ and module_ : Env.t -> Module.t -> Module.t =
         Some (expansion env e)
       with
       | Expand_tools.ExpandFailure `OpaqueModule -> None
-      | Tools.UnresolvedForwardPath -> None
       | e ->
         Format.fprintf Format.err_formatter "Failed to expand module id: %a\n%!%a\n%!" Component.Fmt.model_identifier (m.id :> Odoc_model.Paths.Identifier.t) Component.Fmt.module_ m';
         raise e

--- a/src/xref2/expand_tools.ml
+++ b/src/xref2/expand_tools.ml
@@ -1,3 +1,5 @@
+exception ExpandFailure of [ `OpaqueModule ]
+
 type expansion =
   | Signature of Component.Signature.t
   | Functor of Component.FunctorParameter.t * Component.ModuleType.expr
@@ -54,7 +56,7 @@ and aux_expansion_of_module_type_expr env expr : expansion =
 and aux_expansion_of_module_type env mt =
   let open Component.ModuleType in
   match mt.expr with
-  | None -> raise Tools.OpaqueModule
+  | None -> raise (ExpandFailure `OpaqueModule)
   | Some expr -> aux_expansion_of_module_type_expr env expr
 
 and handle_expansion env id expansion =
@@ -93,7 +95,7 @@ and handle_expansion env id expansion =
           try
             (aux_expansion_of_module_type_expr env' expr')
           with
-          | Tools.OpaqueModule -> Signature { items = []; removed = [] }
+          | ExpandFailure `OpaqueModule -> Signature { items = []; removed = [] }
         in
         expand (`Result id) env' (arg :: args) res
   in

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -773,7 +773,7 @@ and type_decl : Env.t -> TypeDecl.t -> TypeDecl.t =
           Component.Of_Lang.resolved_type_path Component.Of_Lang.empty p
         in
         match Tools.lookup_type_from_resolved_path env p' with
-        | _, Found (`T t') -> (
+        | Ok (_, Found (`T t')) -> (
             try
               (* Format.fprintf Format.err_formatter "XXXXXXX - replacing type at id %a maybe: %a\n%!" Component.Fmt.model_identifier (t.id :> Paths.Identifier.t) Component.Fmt.resolved_type_path p'; *)
               {

--- a/src/xref2/ref_tools.ml
+++ b/src/xref2/ref_tools.ml
@@ -64,10 +64,16 @@ module Memos2 = Hashtbl.Make (Hashable2)
 let memo2 = Memos2.create 91
 
 let module_lookup_to_signature_lookup : Env.t -> module_lookup_result -> signature_lookup_result option =
-  fun env (ref, cp, m) -> Some ((ref :> Resolved.Signature.t), `Module cp, Tools.signature_of_module env m)
+  fun env (ref, cp, m) ->
+    match Tools.signature_of_module env m with
+    | Ok sg -> Some ((ref :> Resolved.Signature.t), `Module cp, sg)
+    | Error _ -> None
 
 let module_type_lookup_to_signature_lookup : Env.t -> module_type_lookup_result -> signature_lookup_result option =
-  fun env (ref, cp, m) -> Some ((ref :> Resolved.Signature.t), `ModuleType cp, Tools.signature_of_module_type env m)
+  fun env (ref, cp, m) ->
+    match Tools.signature_of_module_type env m with
+    | Ok sg -> Some ((ref :> Resolved.Signature.t), `ModuleType cp, sg)
+    | Error _ -> None
 
 
 let rec add_canonical_path : Env.t -> Component.Module.t -> Odoc_model.Paths.Reference.Resolved.Module.t -> Odoc_model.Paths.Reference.Resolved.Module.t =

--- a/src/xref2/tools.ml
+++ b/src/xref2/tools.ml
@@ -212,10 +212,6 @@ exception ModuleType_lookup_failure of Env.t * Cpath.Resolved.module_type
 
 exception ClassType_lookup_failure of Env.t * Cpath.Resolved.class_type
 
-exception MyFailure of Component.Module.t * Component.Module.t
-
-exception Couldnt_find_functor_argument
-
 module Hashable = struct
   type t = Cpath.Resolved.module_
 
@@ -581,12 +577,10 @@ and lookup_and_resolve_module_from_path :
             return (handle_apply is_resolve env func_path' arg_path' m)
         | Unresolved func_path', Resolved (arg_path', _) ->
             Unresolved (`Apply (func_path', `Resolved arg_path'))
-        | Resolved (_func_path', _), Unresolved _arg_path' ->
-            failwith "Unable to find argument"
-            (* Unresolved (`Apply (`Resolved func_path', arg_path')) *)
-        | Unresolved _func_path', Unresolved _arg_path' ->
-            failwith "Unable to find argument"    
-            (* Unresolved (`Apply (func_path', arg_path')) ) *)
+        | Resolved (func_path', _), Unresolved arg_path' ->
+            Unresolved (`Apply (`Resolved func_path', arg_path'))
+        | Unresolved func_path', Unresolved arg_path' ->
+            Unresolved (`Apply (func_path', arg_path'))
     )
     | `Resolved (`Identifier i as resolved_path) ->
         let m = Env.lookup_module i env in

--- a/src/xref2/tools.ml
+++ b/src/xref2/tools.ml
@@ -677,10 +677,10 @@ and lookup_and_resolve_module_from_path :
     | `Resolved (`Identifier i as resolved_path) ->
         let m = Env.lookup_module i env in
         return (process_module_path env add_canonical m resolved_path, m)
-    | `Resolved r -> (
+    | `Resolved r as unresolved -> (
         match lookup_module env r with
         | Ok m -> return (process_module_path env add_canonical m r, m)
-        | Error _ -> Unresolved (`Resolved r) )
+        | Error _ -> Unresolved unresolved )
     | `Substituted s ->
         lookup_and_resolve_module_from_path is_resolve add_canonical env s
         |> map_unresolved (fun p -> `Substituted p)

--- a/src/xref2/tools.ml
+++ b/src/xref2/tools.ml
@@ -1657,7 +1657,7 @@ and reresolve_type_fragment : Env.t -> Cfrag.resolved_type -> Cfrag.resolved_typ
 let rec class_signature_of_class :
     Env.t ->
     Component.Class.t ->
-    Component.ClassSignature.t =
+    Component.ClassSignature.t option =
  fun env c ->
   let rec inner decl =
     match decl with
@@ -1670,22 +1670,18 @@ let rec class_signature_of_class :
 and class_signature_of_class_type_expr :
     Env.t ->
     Component.ClassType.expr ->
-    Component.ClassSignature.t =
+    Component.ClassSignature.t option =
  fun env e ->
   match e with
-  | Signature s -> s
+  | Signature s -> Some s
   | Constr (p, _) -> (
-      let c =
-        match lookup_class_type_from_path env p with
-        | Resolved (_, c) -> c
-        | _ -> failwith "error"
-      in
-      match c with
-      | `C c -> class_signature_of_class env c
-      | `CT c -> class_signature_of_class_type env c )
+      match lookup_class_type_from_path env p with
+      | Resolved (_, `C c) -> class_signature_of_class env c
+      | Resolved (_, `CT c) -> class_signature_of_class_type env c
+      | _ -> None )
 
 and class_signature_of_class_type :
     Env.t ->
     Component.ClassType.t ->
-    Component.ClassSignature.t =
+    Component.ClassSignature.t option =
  fun env c -> class_signature_of_class_type_expr env c.expr

--- a/src/xref2/tools.ml
+++ b/src/xref2/tools.ml
@@ -231,7 +231,7 @@ type signature_of_module_error = [
 ]
 
 type module_lookup_error = [
-  | `Failure of Env.t * Ident.module_ (** Found local path *)
+  | `Local of Env.t * Ident.module_ (** Found local path *)
   | `Unresolved_apply (** [`Apply] argument is not [`Resolved] *)
   | `Find_failure
   | `Parent_module_type of module_type_lookup_error
@@ -249,7 +249,7 @@ and module_type_expr_of_module_error = [
 ]
 
 and module_type_lookup_error = [
-  | `Failure of Env.t * Cpath.Resolved.module_type
+  | `Local of Env.t * Cpath.Resolved.module_type
   | `Find_failure
   | `Parent_module of module_lookup_error
   | `Parent of module_type_lookup_error
@@ -257,14 +257,14 @@ and module_type_lookup_error = [
 ]
 
 and type_lookup_error = [
-  | `Failure of Env.t * Cpath.Resolved.type_
+  | `Local of Env.t * Cpath.Resolved.type_
   | `Unhandled of Cpath.Resolved.type_
   | `Parent_module of module_lookup_error
   | `Parent_sig of signature_of_module_error
 ]
 
 and class_type_lookup_error = [
-  | `Failure of Env.t * Cpath.Resolved.class_type
+  | `Local of Env.t * Cpath.Resolved.class_type
   | `Unhandled of Cpath.Resolved.class_type
   | `Parent_module of module_lookup_error
   | `Parent_sig of signature_of_module_error
@@ -455,7 +455,7 @@ and lookup_module : Env.t -> Cpath.Resolved.module_ -> (Component.Module.t, modu
   let env_id = Env.id env' in
   let lookup env =
     match path with
-    | `Local lpath -> Error (`Failure (env, lpath))
+    | `Local lpath -> Error (`Local (env, lpath))
     | `Identifier i -> Ok (Env.lookup_module i env)
     | `Substituted x -> lookup_module env x
     | `Apply (functor_path, `Resolved argument_path) -> (
@@ -593,7 +593,7 @@ and lookup_module_type :
   fun env path ->
     let lookup env =
       match path with
-      | `Local _ -> Error (`Failure (env, path))
+      | `Local _ -> Error (`Local (env, path))
       | `Identifier i -> Ok (Env.lookup_module_type i env)
       | `Substituted s -> lookup_module_type env s
       | `SubstT (_, p2) -> lookup_module_type env p2
@@ -770,7 +770,7 @@ and lookup_type_from_resolved_path :
   (* let start_time = Unix.gettimeofday () in *)
   (* Format.fprintf Format.err_formatter "lookup_type_from_resolved_path\n%!"; *)
   let res = match p with
-  | `Local _id -> Error (`Failure (env, p))
+  | `Local _id -> Error (`Local (env, p))
   | `Identifier (`CoreType name) ->
       (* CoreTypes aren't put into the environment, so they can't be handled by the
             next clause. We just look them up here in the list of core types *)
@@ -883,7 +883,7 @@ and lookup_class_type_from_resolved_path :
     Env.t -> Cpath.Resolved.class_type -> (class_type_lookup_result, class_type_lookup_error) result =
  fun env p ->
   match p with
-  | `Local _id -> Error (`Failure (env, p))
+  | `Local _id -> Error (`Local (env, p))
   | `Identifier (`Class _ as c) ->
       let t = Env.lookup_class c env in
       Ok (`Identifier c, `C t)


### PR DESCRIPTION
This PR change `Tools` to not use exceptions:
- Lookup functions now return `result`
- "_of_" and "resolve_" functions now return `option`

This PR is not enough to start working on https://github.com/jonludlam/odoc/issues/14. TODO next (PRs following):
- Don't raise in `Find`
- Don't raise in `Env`

Some exceptions are added to other modules (eg. `Link_type_expression_package`, `Compile_module_type_expr`, `Expand_tools.ExpandFailure`)
and some exceptions remains (eg. `failwith "Can't happen"`).
They are now fatal unhandled exceptions and should not be caught until they are removed.

I added `StdResultMonad` and some error types, they are meant for debugging. They can be removed to reduce the diff size. A lot of error cases can probably be replaced by `Resolved | Unresolved`, that will improve #14 too.