### PR TITLE
Don't raise in `Find`

### DIFF
--- a/src/xref2/compile.ml
+++ b/src/xref2/compile.ml
@@ -229,25 +229,11 @@ and module_ : Env.t -> Module.t -> Module.t =
               Component.Fmt.module_ m';
             raise e
     in
-    try
-      {
-        m with
-        type_ = module_decl env' (m.id :> Paths.Identifier.Signature.t) m.type_;
-        expansion;
-      }
-    with
-    | Find.Find_failure (sg, name, ty) as e ->
-        let bt = Printexc.get_backtrace () in
-        Format.fprintf Format.err_formatter
-          "Find failure: Failed to find %s %s in %a\n" ty name
-          Component.Fmt.signature sg;
-        Printf.fprintf stderr "Backtrace: %s\n%!" bt;
-        raise e
-    | e ->
-        Printf.fprintf stderr "Failed to resolve module: %s\n%s\n%!"
-          (Printexc.to_string e)
-          (Printexc.get_backtrace ());
-        raise e
+    {
+      m with
+      type_ = module_decl env' (m.id :> Paths.Identifier.Signature.t) m.type_;
+      expansion;
+    }
 
 and module_decl :
     Env.t -> Paths.Identifier.Signature.t -> Module.decl -> Module.decl =

--- a/src/xref2/find.ml
+++ b/src/xref2/find.ml
@@ -1,9 +1,5 @@
 open Component
 
-exception Find_failure of Signature.t * string * string
-
-let fail sg name ty = raise (Find_failure (sg, name, ty))
-
 type class_type = [ `C of Class.t | `CT of ClassType.t ]
 
 type type_ = [ `T of TypeDecl.t | class_type ]

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -491,13 +491,6 @@ and module_ : Env.t -> Module.t -> Module.t =
         (t1 -. start_time) (t2 -. t1) (t3 -. t2) (t4 -. t3) (end_time -. t4);
       result
     with
-    | Find.Find_failure (sg, name, ty) as e ->
-        let bt = Printexc.get_backtrace () in
-        Format.fprintf Format.err_formatter
-          "Find failure: Failed to find %s %s in %a\n" ty name
-          Component.Fmt.signature sg;
-        Printf.fprintf stderr "Backtrace: %s\n%!" bt;
-        raise e
     | Env.MyFailure (x, _) as e ->
         Format.fprintf Format.err_formatter
           "Failed to expand module: looking up identifier %a while expanding \

--- a/src/xref2/ref_tools.ml
+++ b/src/xref2/ref_tools.ml
@@ -126,14 +126,13 @@ and process_module env add_canonical m base_path' base_ref' :
 
 and handle_module_lookup env add_canonical id parent_path parent_ref sg =
   match Find.careful_module_in_sig sg id with
-  | Find.Found m ->
+  | Some (Find.Found m) ->
       let mname = Odoc_model.Names.ModuleName.of_string id in
       Some
         (process_module env add_canonical m
            (`Module (parent_path, mname))
            (`Module (parent_ref, mname)))
-  | Replaced _p -> None
-  | exception _ -> None
+  | Some (Replaced _) | None -> None
 
 and resolve_type_reference : Env.t -> Type.t -> type_lookup_result option =
   let open Tools.OptionMonad in

--- a/src/xref2/ref_tools.ml
+++ b/src/xref2/ref_tools.ml
@@ -164,26 +164,26 @@ and resolve_type_reference : Env.t -> Type.t -> type_lookup_result option =
         >>= signature_lookup_result_of_label_parent
         >>= fun (parent', cp, sg) ->
         let sg = Tools.prefix_signature (cp, sg) in
-        Find.opt_type_in_sig sg name >>= fun t ->
+        Find.type_in_sig sg name >>= fun t ->
         return (`Type (parent', TypeName.of_string name), t)
     | `Class (parent, name) -> (
         resolve_signature_reference env parent ~add_canonical:true
         >>= fun (parent', _, sg) ->
-        Find.opt_type_in_sig sg (ClassName.to_string name) >>= function
+        Find.type_in_sig sg (ClassName.to_string name) >>= function
         | `C _ as c -> return (`Class (parent', name), c)
         | _ -> None )
     | `ClassType (parent, name) -> (
         resolve_signature_reference env parent ~add_canonical:true
         >>= fun (parent', cp, sg) ->
         let sg = Tools.prefix_signature (cp, sg) in
-        Find.opt_type_in_sig sg (ClassTypeName.to_string name) >>= function
+        Find.type_in_sig sg (ClassTypeName.to_string name) >>= function
         | `CT _ as c -> return (`ClassType (parent', name), c)
         | _ -> None )
     | `Type (parent, name) -> (
         resolve_signature_reference env parent ~add_canonical:true
         >>= fun (parent', cp, sg) ->
         let sg = Tools.prefix_signature (cp, sg) in
-        Find.opt_type_in_sig sg (TypeName.to_string name) >>= function
+        Find.type_in_sig sg (TypeName.to_string name) >>= function
         | `T _ as c -> return (`Type (parent', name), c)
         | _ -> None )
 
@@ -217,7 +217,7 @@ and find_module_type :
   >>= signature_lookup_result_of_label_parent
   >>= fun (parent', cp, sg) ->
   let sg = Tools.prefix_signature (cp, sg) in
-  (try Some (Tools.handle_module_type_lookup env name cp sg) with _ -> None)
+  Tools.handle_module_type_lookup env name cp sg
   >>= fun (cp', m) ->
   let resolved_ref =
     let base = `ModuleType (parent', ModuleTypeName.of_string name) in

--- a/src/xref2/tools.ml
+++ b/src/xref2/tools.ml
@@ -421,8 +421,8 @@ and handle_module_type_lookup env id p sg =
 and handle_type_lookup id p sg : (type_lookup_result, [> `Find_failure ]) result
     =
   match Find.careful_type_in_sig sg id with
-  | mt -> Ok (`Type (p, Odoc_model.Names.TypeName.of_string id), mt)
-  | exception Find.Find_failure _ -> Error `Find_failure
+  | Some mt -> Ok (`Type (p, Odoc_model.Names.TypeName.of_string id), mt)
+  | None -> Error `Find_failure
 
 and handle_class_type_lookup env id p m =
   signature_of_module_cached env p true m |> map_error (fun e -> `Parent_sig e)


### PR DESCRIPTION
This PR removes the `Find.Find_failure` exception. Errors should be handled by https://github.com/jonludlam/odoc/pull/19

Rebased on top of https://github.com/jonludlam/odoc/pull/19
