### PR TITLE
Don't raise in Expand_tools

### DIFF
--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -455,12 +455,11 @@ and module_ : Env.t -> Module.t -> Module.t =
       match (m.expansion, expansion_needed) with
       | None, true ->
         let env, expansion =
-          try
-            let env, ce = Expand_tools.expansion_of_module env m.id m' in
-            let e = Lang_of.(module_expansion empty sg_id ce) in
-
-            (env, Some e)
-          with Expand_tools.ExpandFailure `OpaqueModule -> (env, None)
+          match Expand_tools.expansion_of_module env m.id m' with
+          | Ok (env, ce) ->
+              let e = Lang_of.(module_expansion empty sg_id ce) in
+              (env, Some e)
+          | Error `OpaqueModule -> (env, None)
         in
         (env, expansion)
       | _ -> (env, m.expansion)
@@ -586,13 +585,11 @@ and functor_parameter_parameter :
   let env, expn =
     match (a.expansion, functor_arg.type_) with
     | None, ModuleType expr -> (
-        try
-          let env, ce =
-            Expand_tools.expansion_of_module_type_expr env sg_id expr
-          in
-          let e = Lang_of.(module_expansion empty sg_id ce) in
-          (env, Some e)
-        with Expand_tools.ExpandFailure `OpaqueModule -> (env, None) )
+        match Expand_tools.expansion_of_module_type_expr env sg_id expr with
+        | Ok (env, ce) ->
+            let e = Lang_of.(module_expansion empty sg_id ce) in
+            (env, Some e)
+        | Error `OpaqueModule -> (env, None) )
     | x, _ -> (env, x)
   in
   let display_expr =

--- a/src/xref2/tools.ml
+++ b/src/xref2/tools.ml
@@ -1,15 +1,7 @@
 open Odoc_model.Names
 open Odoc_model.Paths
 
-module StdResultMonad = struct
-  type ('a, 'b) result = ('a, 'b) Result.result = Ok of 'a | Error of 'b
-
-  let map_error f = function Ok _ as ok -> ok | Error e -> Error (f e)
-
-  let of_option ~error = function Some x -> Ok x | None -> Error error
-
-  let ( >>= ) m f = match m with Ok x -> f x | Error _ as e -> e
-end
+module StdResultMonad = Utils.ResultMonad
 
 (* Add [result] and a bind operator over it in scope *)
 open StdResultMonad

--- a/src/xref2/utils.ml
+++ b/src/xref2/utils.ml
@@ -1,0 +1,11 @@
+(** The [result] type and a bind operator. This module is meant to be opened. *)
+module ResultMonad = struct
+  (** Re-export for compat *)
+  type ('a, 'b) result = ('a, 'b) Result.result = Ok of 'a | Error of 'b
+
+  let map_error f = function Ok _ as ok -> ok | Error e -> Error (f e)
+
+  let of_option ~error = function Some x -> Ok x | None -> Error error
+
+  let ( >>= ) m f = match m with Ok x -> f x | Error _ as e -> e
+end


### PR DESCRIPTION
Remove exceptions in `Expand_tools` and use the `result` type instead.

I added an `Utils` module and moved `ResultMonad` from Tools in it. My work until now use the bind operator on `result` a lot, what do you think ?