### PR TITLE
Non strict mode

### DIFF
--- a/src/model/error.ml
+++ b/src/model/error.ml
@@ -18,22 +18,24 @@ type t = [
   | `Without_location of string
 ]
 
-let full message location =
-  `With_full_location {location; message}
+let kmake k ?suggestion format =
+  format |>
+  Format.kasprintf (fun message ->
+    match suggestion with
+    | None -> k message
+    | Some suggestion -> k (message ^ "\nSuggestion: " ^ suggestion))
 
-let filename_only message file =
-  `With_filename_only {file; message}
+let make ?suggestion format =
+  let k message location = `With_full_location {location; message} in
+  kmake k ?suggestion format
+
+let filename_only ?suggestion format =
+  let k message file = `With_filename_only {file; message} in
+  kmake k ?suggestion format
 
 (** Only used internally *)
 let without_location message =
   `Without_location message
-
-let make ?suggestion format =
-  format |>
-  Printf.ksprintf (fun message ->
-    match suggestion with
-    | None -> full message
-    | Some suggestion -> full (message ^ "\nSuggestion: " ^ suggestion))
 
 let to_string = function
   | `With_full_location {location; message} ->

--- a/src/model/error.mli
+++ b/src/model/error.mli
@@ -1,8 +1,9 @@
 type t
 
 val make :
-  ?suggestion:string -> ('a, unit, string, Location_.span -> t) format4 -> 'a
-val filename_only : string -> string -> t
+  ?suggestion:string -> ('a, Format.formatter, unit, Location_.span -> t) format4 -> 'a
+val filename_only :
+  ?suggestion:string -> ('a, Format.formatter, unit, string -> t) format4 -> 'a
 
 val to_string : t -> string
 

--- a/src/odoc/env.ml
+++ b/src/odoc/env.ml
@@ -92,7 +92,7 @@ module Accessible_paths = struct
         match Root.read file with
         | Ok root -> Some (root, file)
         | Error (`Msg msg) ->
-          let warning = Odoc_model.Error.filename_only msg (Fs.File.to_string file) in
+          let warning = Odoc_model.Error.filename_only "%s" msg (Fs.File.to_string file) in
           prerr_endline (Odoc_model.Error.to_string warning);
           None
         | exception End_of_file ->

--- a/src/xref2/compile.ml
+++ b/src/xref2/compile.ml
@@ -59,7 +59,7 @@ let lookup_failure ~what =
   function
   | `Lookup -> r "lookup"
   | `Expand -> r "compile expansion for"
-  | `Resolve_type -> r "resolve type of"
+  | `Resolve_module_type -> r "resolve type of"
   | `Resolve -> r "resolve"
   | `Compile -> r "compile"
 
@@ -379,7 +379,7 @@ and functor_parameter_parameter :
   let open Utils.ResultMonad in
   let get_module_type_expr = function
     | Component.Module.ModuleType expr -> Ok expr
-    | _ -> Error `Resolve_type
+    | _ -> Error `Resolve_module_type
   in
   match
     Env.lookup_module a.id env' |> of_option ~error:`Lookup
@@ -440,7 +440,7 @@ and module_type_expr :
                 `Resolved
                   (Lang_of.Path.resolved_type_fragment lang_of_map cfrag)
             | None ->
-                lookup_failure ~what:(`With_type frag) `Resolve;
+                lookup_failure ~what:(`With_type frag) `Compile;
                 unresolved
           in
           let sg' = Tools.fragmap_type env frag csub sg in
@@ -468,7 +468,7 @@ and module_type_expr :
                 `Resolved
                   (Lang_of.Path.resolved_type_fragment lang_of_map cfrag)
             | None ->
-                lookup_failure ~what:(`With_type frag) `Resolve;
+                lookup_failure ~what:(`With_type frag) `Compile;
                 unresolved
           in
           let sg' = Tools.fragmap_type env frag csub sg in
@@ -619,7 +619,7 @@ and type_expression_package env p =
               | Some cfrag' ->
                   `Resolved (Lang_of.(Path.resolved_type_fragment empty) cfrag')
               | None ->
-                  lookup_failure ~what:(`Type cfrag) `Resolve;
+                  lookup_failure ~what:(`Type cfrag) `Compile;
                   frag
             in
             (frag', type_expression env t)

--- a/src/xref2/compile.ml
+++ b/src/xref2/compile.ml
@@ -729,9 +729,6 @@ let build_resolver :
   in
   { Env.lookup_unit; resolve_unit; lookup_page; resolve_page; open_units }
 
-let compile x y =
-  let before = y in
-  let after = unit x before in
-  after
+let compile x y = Lookup_failures.catch_failures (fun () -> unit x y)
 
 let resolve_page _resolver y = y

--- a/src/xref2/compile.ml
+++ b/src/xref2/compile.ml
@@ -16,12 +16,6 @@ let type_path : Env.t -> Paths.Path.Type.t -> Paths.Path.Type.t =
   match Tools.lookup_type_from_path env cp with
   | Resolved (p', _) -> `Resolved (Cpath.resolved_type_path_of_cpath p')
   | Unresolved p -> Cpath.type_path_of_cpath p
-  | exception e ->
-      Format.fprintf Format.err_formatter
-        "Failed to lookup type path (%s): %a\n%!" (Printexc.to_string e)
-        Component.Fmt.model_path
-        (p :> Paths.Path.t);
-      p
 
 and module_type_path :
     Env.t -> Paths.Path.ModuleType.t -> Paths.Path.ModuleType.t =
@@ -30,12 +24,6 @@ and module_type_path :
   match Tools.lookup_and_resolve_module_type_from_path true env cp with
   | Resolved (p', _) -> `Resolved (Cpath.resolved_module_type_path_of_cpath p')
   | Unresolved p -> Cpath.module_type_path_of_cpath p
-  | exception e ->
-      Format.fprintf Format.err_formatter
-        "Failed to lookup module_type path (%s): %a\n%!" (Printexc.to_string e)
-        Component.Fmt.model_path
-        (p :> Paths.Path.t);
-      p
 
 and module_path : Env.t -> Paths.Path.Module.t -> Paths.Path.Module.t =
  fun env p ->
@@ -43,12 +31,6 @@ and module_path : Env.t -> Paths.Path.Module.t -> Paths.Path.Module.t =
   match Tools.resolve_module env cp with
   | Resolved p' -> `Resolved (Cpath.resolved_module_path_of_cpath p')
   | Unresolved p -> Cpath.module_path_of_cpath p
-  | exception e ->
-      Format.fprintf Format.err_formatter
-        "Failed to lookup module path (%s): %a\n%!" (Printexc.to_string e)
-        Component.Fmt.model_path
-        (p :> Paths.Path.t);
-      p
 
 let rec unit (resolver : Env.resolver) t =
   let open Compilation_unit in
@@ -691,12 +673,7 @@ and type_expression : Env.t -> _ -> _ =
           let p = Cpath.resolved_type_path_of_cpath cp in
           Constr (`Resolved p, ts)
       | Resolved (_cp, Replaced x) -> Lang_of.(type_expr empty x)
-      | Unresolved p -> Constr (Cpath.type_path_of_cpath p, ts)
-      | exception e ->
-          Format.fprintf Format.err_formatter
-            "Exception handling type expression: %a\n%!" Component.Fmt.type_expr
-            Component.Of_Lang.(type_expression empty texpr);
-          raise e )
+      | Unresolved p -> Constr (Cpath.type_path_of_cpath p, ts) )
   | Polymorphic_variant v -> Polymorphic_variant (type_expression_polyvar env v)
   | Object o -> Object (type_expression_object env o)
   | Class (path, ts) -> Class (path, List.map (type_expression env) ts)

--- a/src/xref2/env.ml
+++ b/src/xref2/env.ml
@@ -586,33 +586,21 @@ let add_functor_args' :
     in
     env'
 
-let lookup_module' id env =
-  match lookup_module id env with
-  | None -> None
-  | Some m ->
-      let env' =
-        match m.Component.Module.type_ with
-        | Alias _ -> env
-        | ModuleType expr ->
-            add_functor_args'
-              (id :> Odoc_model.Paths.Identifier.Signature.t)
-              expr env
-      in
-      Some (m, env')
+let add_module_functor_args m id env =
+  match m.Component.Module.type_ with
+  | Alias _ -> env
+  | ModuleType expr ->
+    add_functor_args'
+      (id :> Odoc_model.Paths.Identifier.Signature.t)
+      expr env
 
-let lookup_module_type' id env =
-  match lookup_module_type id env with
-  | None -> None
-  | Some mt ->
-      let env' =
-        match mt.Component.ModuleType.expr with
-        | None -> env
-        | Some expr ->
-            add_functor_args'
-              (id :> Odoc_model.Paths.Identifier.Signature.t)
-              expr env
-      in
-      Some (mt, env')
+let add_module_type_functor_args mt id env =
+  match mt.Component.ModuleType.expr with
+  | None -> env
+  | Some expr ->
+    add_functor_args'
+      (id :> Odoc_model.Paths.Identifier.Signature.t)
+      expr env
 
 let open_class_signature : Odoc_model.Lang.ClassSignature.t -> t -> t =
   let open Component in

--- a/src/xref2/env.mli
+++ b/src/xref2/env.mli
@@ -131,6 +131,12 @@ val lookup_module :
   Odoc_model.Paths_types.Identifier.reference_module -> t ->
   Component.Module.t option
 
+val lookup_module' :
+  Odoc_model.Paths_types.Identifier.reference_module -> t ->
+  (Component.Module.t * t) option
+(** Lookup a module in the environment, return an environment with functor
+    parameters added. *)
+
 val lookup_type :
   Odoc_model.Paths_types.Identifier.type_ -> t -> Component.TypeDecl.t option
 
@@ -138,6 +144,13 @@ val lookup_module_type :
   Odoc_model.Paths_types.Identifier.reference_module_type ->
   t ->
   Component.ModuleType.t option
+
+val lookup_module_type' :
+  Odoc_model.Paths_types.Identifier.reference_module_type ->
+  t ->
+  (Component.ModuleType.t * t) option
+(** Lookup a module in the environment, return an environment with functor
+    parameters added. *)
 
 val lookup_value :
   Odoc_model.Paths_types.Identifier.value -> t -> Component.Value.t
@@ -178,8 +191,6 @@ val lookup_value_by_name :
   [ `External of Odoc_model.Paths_types.Identifier.value * Component.External.t
   | `Value of Odoc_model.Paths_types.Identifier.value * Component.Value.t ]
   option
-
-val add_functor_args : Odoc_model.Paths_types.Identifier.signature -> t -> t option
 
 (* val open_component_signature :
   Odoc_model.Paths_types.Identifier.signature -> Component.Signature.t -> t -> t *)

--- a/src/xref2/env.mli
+++ b/src/xref2/env.mli
@@ -125,17 +125,18 @@ val add_method :
 
 val add_root : string -> root -> t -> t
 
+val add_module_functor_args :
+  Component.Module.t -> Odoc_model.Paths_types.Identifier.module_ -> t -> t
+
+val add_module_type_functor_args :
+  Component.ModuleType.t -> Odoc_model.Paths_types.Identifier.module_type -> t -> t
+
 val lookup_fragment_root : t -> (int * Component.Signature.t) option
 
 val lookup_module :
-  Odoc_model.Paths_types.Identifier.reference_module -> t ->
+  Odoc_model.Paths_types.Identifier.reference_module ->
+  t ->
   Component.Module.t option
-
-val lookup_module' :
-  Odoc_model.Paths_types.Identifier.reference_module -> t ->
-  (Component.Module.t * t) option
-(** Lookup a module in the environment, return an environment with functor
-    parameters added. *)
 
 val lookup_type :
   Odoc_model.Paths_types.Identifier.type_ -> t -> Component.TypeDecl.t option
@@ -144,13 +145,6 @@ val lookup_module_type :
   Odoc_model.Paths_types.Identifier.reference_module_type ->
   t ->
   Component.ModuleType.t option
-
-val lookup_module_type' :
-  Odoc_model.Paths_types.Identifier.reference_module_type ->
-  t ->
-  (Component.ModuleType.t * t) option
-(** Lookup a module in the environment, return an environment with functor
-    parameters added. *)
 
 val lookup_value :
   Odoc_model.Paths_types.Identifier.value -> t -> Component.Value.t
@@ -161,10 +155,14 @@ val lookup_section_title :
   Odoc_model.Comment.link_content option
 
 val lookup_class :
-  Odoc_model.Paths_types.Identifier.reference_class -> t -> Component.Class.t option
+  Odoc_model.Paths_types.Identifier.reference_class ->
+  t ->
+  Component.Class.t option
 
 val lookup_class_type :
-  Odoc_model.Paths_types.Identifier.class_type -> t -> Component.ClassType.t option
+  Odoc_model.Paths_types.Identifier.class_type ->
+  t ->
+  Component.ClassType.t option
 
 val lookup_page : string -> t -> Odoc_model.Lang.Page.t option
 

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -937,14 +937,13 @@ let build_resolver :
   { Env.lookup_unit; resolve_unit; lookup_page; resolve_page }
 *)
 let link x y =
-  let before = y in
-  let after = unit x before in
-  after
+  Lookup_failures.catch_failures (fun () -> unit x y)
 
 let resolve_page resolver y =
   let env = Env.set_resolver Env.empty resolver in
-  {
-    y with
-    Page.content =
-      List.map (with_location comment_block_element env) y.Page.content;
-  }
+  Lookup_failures.catch_failures (fun () ->
+      {
+        y with
+        Page.content =
+          List.map (with_location comment_block_element env) y.Page.content;
+      })

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -385,7 +385,10 @@ and module_ : Env.t -> Module.t -> Module.t =
     let m', env =
       match Env.lookup_module' m.id env with
       | Some ((_, _) as x) -> x
-      | None -> raise Not_found
+      | None ->
+          Format.kasprintf failwith "Failed to lookup module %a"
+            Component.Fmt.model_identifier
+            (m.id :> Paths.Identifier.t)
     in
     let t2 = Unix.gettimeofday () in
     let type_ = module_decl env m.type_ in
@@ -415,7 +418,10 @@ and module_ : Env.t -> Module.t -> Module.t =
                 let e = Lang_of.(module_expansion empty sg_id ce) in
                 (env, Some e)
             | Error `OpaqueModule -> (env, None)
-            | Error _ -> failwith "expand module"
+            | Error _ ->
+                Format.kasprintf failwith "Failed to expand module %a"
+                  Component.Fmt.model_identifier
+                  (m.id :> Paths.Identifier.t)
           in
           (env, expansion)
       | _ -> (env, m.expansion)

--- a/src/xref2/lookup_failures.ml
+++ b/src/xref2/lookup_failures.ml
@@ -1,0 +1,37 @@
+let strict_mode = ref false
+
+type 'a with_failures = 'a * string list
+
+let failure_acc = ref []
+
+let add f = failure_acc := f :: !failure_acc
+
+let catch_failures f =
+  let prev = !failure_acc in
+  failure_acc := [];
+  let r = f () in
+  let failures = !failure_acc in
+  failure_acc := prev;
+  (r, List.rev failures)
+
+(** Report a lookup failure to the enclosing [catch_failures] call. *)
+let report fmt = Format.kasprintf add fmt
+
+(** Like [report] above but may raise the exception [exn] if strict mode is enabled *)
+let report_important exn fmt =
+  if !strict_mode then raise exn else Format.kasprintf add fmt
+
+let pp = Format.pp_print_string
+
+let pp_failures ppf fs = List.iter (Format.fprintf ppf "%a@\n" pp) fs
+
+let to_warning ~filename (r, failures) =
+  let open Odoc_model.Error in
+  accumulate_warnings (fun warnings ->
+      match failures with
+      | [] -> r
+      | _ :: _ ->
+          warning warnings
+            (filename_only "The following lookup failures occurred:@\n%a"
+               pp_failures failures filename);
+          r)

--- a/src/xref2/lookup_failures.mli
+++ b/src/xref2/lookup_failures.mli
@@ -1,0 +1,18 @@
+(** Report non-fatal errors *)
+
+type 'a with_failures
+(** A value that may be partially unresolved due to failures. *)
+
+val catch_failures : (unit -> 'a) -> 'a with_failures
+
+val report : ('fmt, Format.formatter, unit, unit) format4 -> 'fmt
+(** Report a lookup failure to the enclosing [catch_failures] call. *)
+
+val report_important :
+  exn -> ('fmt, Format.formatter, unit, unit) format4 -> 'fmt
+(** Like [report] above but may raise the exception [exn] if strict mode is
+    enabled *)
+
+val to_warning :
+  filename:string -> 'a with_failures -> 'a Odoc_model.Error.with_warnings
+(** Convert the failures to a warning. *)

--- a/src/xref2/tools.ml
+++ b/src/xref2/tools.ml
@@ -6,20 +6,13 @@ module StdResultMonad = Utils.ResultMonad
 (* Add [result] and a bind operator over it in scope *)
 open StdResultMonad
 
-type ('a, 'b) either = Left of 'a | Right of 'b
-
 module OptionMonad = struct
-  type 'a t = 'a option
+  include Utils.OptionMonad
 
   let return x = Some x
-
-  let bind m f = match m with Some x -> f x | None -> None
-
-  (* The error case become [None], the error value is ignored. *)
-  let of_result = function StdResultMonad.Ok x -> Some x | Error _ -> None
-
-  let ( >>= ) = bind
 end
+
+type ('a, 'b) either = Left of 'a | Right of 'b
 
 module ResultMonad = struct
   type ('a, 'b) t = Resolved of 'a | Unresolved of 'b

--- a/src/xref2/utils.ml
+++ b/src/xref2/utils.ml
@@ -9,3 +9,11 @@ module ResultMonad = struct
 
   let ( >>= ) m f = match m with Ok x -> f x | Error _ as e -> e
 end
+
+(** A bind operator for the [option] type. This module is meant to be opened. *)
+module OptionMonad = struct
+  (* The error case become [None], the error value is ignored. *)
+  let of_result = function Result.Ok x -> Some x | Error _ -> None
+
+  let ( >>= ) m f = match m with Some x -> f x | None -> None
+end


### PR DESCRIPTION
Allow failures when resolving paths and references. (#14)

The Lookup_failures module uses a global ref to store failures. Failures are caught at the entry points of Odoc_xref2 and turned into a warning in Odoc_odoc.

This is not enough to close the issue:
- [ ] Strict mode cannot be turned on
  I thought warnings could be a good mechanism for that. (They can be made fatal)
  Warnings are not enough if we need to abort the process at the first error (eg. to have the backtrace or avoid cascade of failures).

Some exceptions remain, they are still fatal:
- [ ] Exception `Link.Loop`
- [ ] `Link.module_` still raises on lookup/expand failure
- [ ] Most `Lang_of` functions still raise

Some `failwith "Can't happen"` remain, they look exceptional and should be handled separately.

Rebased on top of https://github.com/jonludlam/odoc/pull/23