### PR TITLE
Don't look at canonical paths when resolving references

### DIFF
--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -196,9 +196,7 @@ and comment_nestable_block_element env (x : Comment.nestable_block_element) =
       let refs =
         List.map
           (fun r ->
-            match
-              Ref_tools.resolve_module_reference env ~add_canonical:false r
-            with
+            match Ref_tools.resolve_module_reference env r with
             | Some (r, _, _) -> `Resolved r
             | None -> r)
           refs

--- a/test/html/expect/test_package+ml/Ocamlary/index.html
+++ b/test/html/expect/test_package+ml/Ocamlary/index.html
@@ -1636,7 +1636,7 @@
     </dt>
     <dd>
      <p>
-      Some ref to <a href="CanonicalTest/Base__Tests/C/index.html#type-t"><code>CanonicalTest.Base__Tests.C.t</code></a> and <a href="CanonicalTest/Base/List/index.html#val-id"><code>CanonicalTest.Base__Tests.L.id</code></a>. But also to <a href="CanonicalTest/Base/List/index.html"><code>Ocamlary.CanonicalTest.Base.List</code></a> and <a href="CanonicalTest/Base/List/index.html#type-t"><code>Ocamlary.CanonicalTest.Base.List.t</code></a>
+      Some ref to <a href="CanonicalTest/Base__Tests/C/index.html#type-t"><code>CanonicalTest.Base__Tests.C.t</code></a> and <a href="CanonicalTest/Base/List/index.html#val-id"><code>CanonicalTest.Base__Tests.L.id</code></a>. But also to <a href="CanonicalTest/Base__/List/index.html"><code>CanonicalTest.Base__.List</code></a> and <a href="CanonicalTest/Base__/List/index.html#type-t"><code>CanonicalTest.Base__.List.t</code></a>
      </p>
     </dd>
    </dl>

--- a/test/html/expect/test_package+re/Ocamlary/index.html
+++ b/test/html/expect/test_package+re/Ocamlary/index.html
@@ -1644,7 +1644,7 @@
     </dt>
     <dd>
      <p>
-      Some ref to <a href="CanonicalTest/Base__Tests/C/index.html#type-t"><code>CanonicalTest.Base__Tests.C.t</code></a> and <a href="CanonicalTest/Base/List/index.html#val-id"><code>CanonicalTest.Base__Tests.L.id</code></a>. But also to <a href="CanonicalTest/Base/List/index.html"><code>Ocamlary.CanonicalTest.Base.List</code></a> and <a href="CanonicalTest/Base/List/index.html#type-t"><code>Ocamlary.CanonicalTest.Base.List.t</code></a>
+      Some ref to <a href="CanonicalTest/Base__Tests/C/index.html#type-t"><code>CanonicalTest.Base__Tests.C.t</code></a> and <a href="CanonicalTest/Base/List/index.html#val-id"><code>CanonicalTest.Base__Tests.L.id</code></a>. But also to <a href="CanonicalTest/Base__/List/index.html"><code>CanonicalTest.Base__.List</code></a> and <a href="CanonicalTest/Base__/List/index.html#type-t"><code>CanonicalTest.Base__.List.t</code></a>
      </p>
     </dd>
    </dl>


### PR DESCRIPTION
References are written by users so they should already be canonical.

Example diff on Base:

```diff
     <h1>Module <code>Bigarray.Array0</code></h1>
     <p>Zero-dimensional arrays. The <code>Array0</code> structure
     provides operations similar to those of
-    <a href="../../../../ocaml/Stdlib/Bigarray/Genarray/index.html">
-      <code>Stdlib.Bigarray.Genarray</code>
+    <a href="../Genarray/index.html">
+      <code>Bigarray.Genarray</code>
     </a>,
     but specialized to the case of zero-dimensional arrays that
     only contain a single scalar value. Statically knowing the
     number of dimensions of the array allows faster operations, and
```