### PR TITLE
Lighter env

### DIFF
--- a/src/xref2/compile.ml
+++ b/src/xref2/compile.ml
@@ -234,11 +234,11 @@ and module_ : Env.t -> Module.t -> Module.t =
       (* Aliases are expanded if necessary during link *)
     in
     (* Format.fprintf Format.err_formatter "Handling module: %a\n" Component.Fmt.model_identifier (m.id :> Id.t); *)
-    match Env.lookup_module m.id env with
+    match Env.(lookup_by_id s_module) m.id env with
     | None ->
         lookup_failure ~what:(`Module m.id) `Lookup;
         m
-    | Some m' ->
+    | Some (`Module (_, m')) ->
         let env' = Env.add_module_functor_args m' m.id env in
         let expansion =
           let sg_id = (m.id :> Id.Signature.t) in
@@ -413,8 +413,8 @@ and functor_parameter_parameter :
     | _ -> Error `Resolve_module_type
   in
   match
-    Env.lookup_module a.id env' |> of_option ~error:`Lookup
-    >>= fun functor_arg ->
+    Env.(lookup_by_id s_module) a.id env' |> of_option ~error:`Lookup
+    >>= fun (`Module (_, functor_arg)) ->
     let env = Env.add_module_functor_args functor_arg a.id env' in
     get_module_type_expr functor_arg.type_ >>= fun expr ->
     match Expand_tools.expansion_of_module_type_expr env sg_id expr with

--- a/src/xref2/compile.ml
+++ b/src/xref2/compile.ml
@@ -123,7 +123,7 @@ and class_type env parent c =
   let expansion =
     match
       let open Utils.OptionMonad in
-      Env.lookup_class_type c.id env >>= fun c' ->
+      Env.(lookup_by_id s_class_type) c.id env >>= fun (`ClassType (_, c')) ->
       Tools.class_signature_of_class_type env c' >>= fun sg ->
       Some
         (Lang_of.class_signature Lang_of.empty
@@ -171,7 +171,7 @@ and class_ env parent c =
   let expansion =
     match
       let open Utils.OptionMonad in
-      Env.lookup_class c.id env >>= fun c' ->
+      Env.(lookup_by_id s_class) c.id env >>= fun (`Class (_, c')) ->
       Tools.class_signature_of_class env c' >>= fun sg ->
       Some
         (Lang_of.class_signature Lang_of.empty

--- a/src/xref2/compile.ml
+++ b/src/xref2/compile.ml
@@ -298,7 +298,8 @@ and module_type : Env.t -> ModuleType.t -> ModuleType.t =
             Some (module_type_expr env (m.id :> Id.Signature.t) expr) )
   in
   match
-    Env.lookup_module_type m.id env |> of_option ~error:`Lookup >>= fun m' ->
+    Env.(lookup_by_id s_module_type) m.id env |> of_option ~error:`Lookup
+    >>= fun (`ModuleType (_, m')) ->
     let env = Env.add_module_type_functor_args m' m.id env in
     expand m' env
   with

--- a/src/xref2/env.ml
+++ b/src/xref2/env.ml
@@ -67,17 +67,9 @@ module StringMap = Map.Make (String)
 
 type t = {
   id : int;
-  types : Component.TypeDecl.t Maps.Type.t;
-  values : Component.Value.t Maps.Value.t;
-  externals : Component.External.t Maps.Value.t;
   titles : Odoc_model.Comment.link_content Maps.Label.t;
-  classes : Component.Class.t Maps.Class.t;
-  class_types : Component.ClassType.t Maps.ClassType.t;
   methods : Component.Method.t Maps.Method.t;
-  instance_variables : Component.InstanceVariable.t Maps.InstanceVariable.t;
   constructors : Component.TypeDecl.Constructor.t Maps.Constructor.t;
-  exceptions : Component.Exception.t Maps.Exception.t;
-  extensions : Component.Extension.Constructor.t Maps.Extension.t;
   fields : Component.TypeDecl.Field.t Maps.Field.t;
   elts : Component.Element.any list StringMap.t;
   resolver : resolver option;
@@ -107,55 +99,14 @@ let with_recorded_lookups env f =
     restore ();
     raise e
 
-let pp_types ppf types =
-  List.iter
-    (fun (i, m) ->
-      Format.fprintf ppf "%a: %a @," Component.Fmt.model_identifier
-        (i :> Odoc_model.Paths.Identifier.t)
-        Component.Fmt.type_decl m)
-    (Maps.Type.bindings types)
-
-let pp_values ppf values =
-  List.iter
-    (fun (i, v) ->
-      Format.fprintf ppf "%a: %a @," Component.Fmt.model_identifier
-        (i :> Odoc_model.Paths.Identifier.t)
-        Component.Fmt.value v)
-    (Maps.Value.bindings values)
-
-let pp_externals ppf exts =
-  List.iter
-    (fun (i, e) ->
-      Format.fprintf ppf "%a: %a @," Component.Fmt.model_identifier
-        (i :> Odoc_model.Paths.Identifier.t)
-        Component.Fmt.external_ e)
-    (Maps.Value.bindings exts)
-
-let pp ppf env =
-  Format.fprintf ppf
-    "@[<v>@,\
-     ENV types: %a@,\
-     ENV values: %a@,\
-     ENV externals: %a@,\
-     END OF ENV"
-    pp_types env.types pp_values env.values pp_externals env.externals
-
 let empty =
   {
     id = 0;
-    types = Maps.Type.empty;
-    values = Maps.Value.empty;
-    externals = Maps.Value.empty;
     titles = Maps.Label.empty;
     elts = StringMap.empty;
-    classes = Maps.Class.empty;
-    class_types = Maps.ClassType.empty;
     methods = Maps.Method.empty;
-    instance_variables = Maps.InstanceVariable.empty;
     constructors = Maps.Constructor.empty;
     fields = Maps.Field.empty;
-    exceptions = Maps.Exception.empty;
-    extensions = Maps.Extension.empty;
     resolver = None;
     recorder = None;
     fragmentroot = None;
@@ -227,7 +178,6 @@ let add_type identifier t env =
     id =
       ( incr unique_id;
         !unique_id );
-    types = Maps.Type.add identifier t env.types;
     constructors;
     fields;
     elts =
@@ -256,7 +206,6 @@ let add_value identifier t env =
     id =
       ( incr unique_id;
         !unique_id );
-    values = Maps.Value.add identifier t env.values;
     elts =
       add_to_elts
         (Odoc_model.Paths.Identifier.name identifier)
@@ -270,7 +219,6 @@ let add_external identifier t env =
     id =
       ( incr unique_id;
         !unique_id );
-    externals = Maps.Value.add identifier t env.externals;
     elts =
       add_to_elts
         (Odoc_model.Paths.Identifier.name identifier)
@@ -305,7 +253,6 @@ let add_class identifier t env =
     id =
       ( incr unique_id;
         !unique_id );
-    classes = Maps.Class.add identifier t env.classes;
     elts =
       add_to_elts
         (Odoc_model.Paths.Identifier.name identifier)
@@ -319,7 +266,6 @@ let add_class_type identifier t env =
     id =
       ( incr unique_id;
         !unique_id );
-    class_types = Maps.ClassType.add identifier t env.class_types;
     elts =
       add_to_elts
         (Odoc_model.Paths.Identifier.name identifier)
@@ -356,7 +302,6 @@ let add_exception identifier e env =
     id =
       ( incr unique_id;
         !unique_id );
-    exceptions = Maps.Exception.add identifier e env.exceptions;
     elts =
       add_to_elts
         (Odoc_model.Paths.Identifier.name identifier)
@@ -370,7 +315,6 @@ let add_extension_constructor identifier ec env =
     id =
       ( incr unique_id;
         !unique_id );
-    extensions = Maps.Extension.add identifier ec env.extensions;
     elts =
       add_to_elts
         (Odoc_model.Paths.Identifier.name identifier)
@@ -463,6 +407,10 @@ let s_datatype : Component.Element.datatype scope = function
   | #Component.Element.datatype as r -> Some r
   | _ -> None
 
+let s_type : Component.Element.type_ scope = function
+  | #Component.Element.type_ as r -> Some r
+  | _ -> None
+
 let s_class : Component.Element.class_ scope = function
   | #Component.Element.class_ as r -> Some r
   | _ -> None
@@ -515,20 +463,8 @@ let lookup_fragment_root env =
       result
   | None -> None
 
-let lookup_type identifier env =
-  try Some (Maps.Type.find identifier env.types) with _ -> None
-
-let lookup_value identifier env =
-  try Some (Maps.Value.find identifier env.values) with _ -> None
-
 let lookup_section_title identifier env =
   try Some (Maps.Label.find identifier env.titles) with _ -> None
-
-let lookup_class identifier env =
-  try Some (Maps.Class.find identifier env.classes) with _ -> None
-
-let lookup_class_type identifier env =
-  try Some (Maps.ClassType.find identifier env.class_types) with _ -> None
 
 let module_of_unit : Odoc_model.Lang.Compilation_unit.t -> Component.Module.t =
  fun unit ->

--- a/src/xref2/env.ml
+++ b/src/xref2/env.ml
@@ -68,7 +68,6 @@ module StringMap = Map.Make (String)
 type t = {
   id : int;
   titles : Odoc_model.Comment.link_content Maps.Label.t;
-  methods : Component.Method.t Maps.Method.t;
   elts : Component.Element.any list StringMap.t;
   resolver : resolver option;
   recorder : recorder option;
@@ -102,7 +101,6 @@ let empty =
     id = 0;
     titles = Maps.Label.empty;
     elts = StringMap.empty;
-    methods = Maps.Method.empty;
     resolver = None;
     recorder = None;
     fragmentroot = None;
@@ -275,14 +273,9 @@ let add_docs (docs : Odoc_model.Comment.docs) env =
 let add_comment (com : Odoc_model.Comment.docs_or_stop) env =
   match com with `Docs doc -> add_docs doc env | `Stop -> env
 
-let add_method identifier m env =
-  {
-    env with
-    id =
-      ( incr unique_id;
-        !unique_id );
-    methods = Maps.Method.add identifier m env.methods;
-  }
+let add_method _identifier _t env =
+  (* TODO *)
+  env
 
 let add_exception identifier e env =
   {

--- a/src/xref2/env.ml
+++ b/src/xref2/env.ml
@@ -358,8 +358,11 @@ let make_scope ?(root = fun _ _ -> None)
   { filter; root }
 
 let lookup_by_name' scope name env =
+  let filter acc r =
+    match scope.filter r with Some r' -> r' :: acc | None -> acc
+  in
   let found = try StringMap.find name env.elts with Not_found -> [] in
-  List.filter_map scope.filter found
+  List.fold_left filter [] found |> List.rev
 
 let lookup_by_name scope name env =
   let record_lookup_results results =

--- a/src/xref2/env.mli
+++ b/src/xref2/env.mli
@@ -182,48 +182,43 @@ val module_of_unit : Odoc_model.Lang.Compilation_unit.t -> Component.Module.t
 
 val lookup_root_module : string -> t -> root option
 
-val find : ('a -> 'b option) -> 'a list -> 'b option
-
-val lookup_any_by_name : string -> t -> Component.Element.any list
-
-val lookup_signature_by_name : string -> t -> Component.Element.signature option
-
-val lookup_module_by_name :
-  string ->
-  t ->
-  (Odoc_model.Paths.Identifier.Module.t * Component.Module.t) option
-
-val lookup_module_type_by_name :
-  string -> t -> Component.Element.module_type option
-
-val lookup_datatype_by_name : string -> t -> Component.Element.datatype option
-
-val lookup_class_by_name : string -> t -> Component.Element.class_ option
-
-val lookup_class_type_by_name :
-  string -> t -> Component.Element.class_type option
-
-val lookup_value_by_name :
-  string ->
-  t ->
+type value_or_external =
   [ `External of Odoc_model.Paths_types.Identifier.value * Component.External.t
   | `Value of Odoc_model.Paths_types.Identifier.value * Component.Value.t ]
-  option
 
-val lookup_label_by_name : string -> t -> Component.Element.label option
+type 'a scope constraint 'a = [< Component.Element.any ]
+(** Target of a lookup *)
 
-val lookup_constructor_by_name :
-  string -> t -> Component.Element.constructor option
+val lookup_by_name : 'a scope -> string -> t -> 'a option
+(** Lookup an element in Env depending on the given [scope]. *)
 
-val lookup_exception_by_name :
-  string -> t -> Component.Element.exception_ option
+val s_any : Component.Element.any scope
 
-val lookup_extension_by_name : string -> t -> Component.Element.extension option
+val s_signature : Component.Element.signature scope
 
-val lookup_field_by_name : string -> t -> Component.Element.field option
+val s_module : Component.Element.module_ scope
 
-val lookup_label_parent_by_name :
-  string -> t -> Component.Element.label_parent option
+val s_module_type : Component.Element.module_type scope
+
+val s_datatype : Component.Element.datatype scope
+
+val s_class : Component.Element.class_ scope
+
+val s_class_type : Component.Element.class_type scope
+
+val s_value : value_or_external scope
+
+val s_label : Component.Element.label scope
+
+val s_constructor : Component.Element.constructor scope
+
+val s_exception : Component.Element.exception_ scope
+
+val s_extension : Component.Element.extension scope
+
+val s_field : Component.Element.field scope
+
+val s_label_parent : Component.Element.label_parent scope
 
 (* val open_component_signature :
   Odoc_model.Paths_types.Identifier.signature -> Component.Signature.t -> t -> t *)

--- a/src/xref2/env.mli
+++ b/src/xref2/env.mli
@@ -32,16 +32,6 @@ val pp_lookup_type_list : Format.formatter -> lookup_type list -> unit
 
 type t
 
-(*val pp_modules :
-    Format.formatter ->
-      (Odoc_model.Paths.Identifier.Module.t *
-       Component.Module.t) list -> unit
-*)
-val pp_module_types :
-  Format.formatter ->
-  Component.ModuleType.t Odoc_model.Paths.Identifier.Maps.ModuleType.t ->
-  unit
-
 val pp_types :
   Format.formatter ->
   Component.TypeDecl.t Odoc_model.Paths.Identifier.Maps.Type.t ->
@@ -152,11 +142,6 @@ val lookup_module :
 
 val lookup_type :
   Odoc_model.Paths_types.Identifier.type_ -> t -> Component.TypeDecl.t option
-
-val lookup_module_type :
-  Odoc_model.Paths_types.Identifier.reference_module_type ->
-  t ->
-  Component.ModuleType.t option
 
 val lookup_value :
   Odoc_model.Paths_types.Identifier.value -> t -> Component.Value.t option

--- a/src/xref2/env.mli
+++ b/src/xref2/env.mli
@@ -118,12 +118,6 @@ val add_module_type_functor_args :
 
 val lookup_fragment_root : t -> (int * Component.Signature.t) option
 
-val lookup_module :
-  Odoc_model.Paths_types.Identifier.reference_module ->
-  t ->
-  Component.Module.t option
-(** Lookup a module by identifier or, if not found, lookup a root module. *)
-
 val lookup_section_title :
   Odoc_model.Paths_types.Identifier.reference_label ->
   t ->

--- a/src/xref2/env.mli
+++ b/src/xref2/env.mli
@@ -32,24 +32,7 @@ val pp_lookup_type_list : Format.formatter -> lookup_type list -> unit
 
 type t
 
-val pp_types :
-  Format.formatter ->
-  Component.TypeDecl.t Odoc_model.Paths.Identifier.Maps.Type.t ->
-  unit
-
-val pp_values :
-  Format.formatter ->
-  Component.Value.t Odoc_model.Paths.Identifier.Maps.Value.t ->
-  unit
-
-val pp_externals :
-  Format.formatter ->
-  Component.External.t Odoc_model.Paths.Identifier.Maps.Value.t ->
-  unit
-
 val with_recorded_lookups : t -> (t -> 'a) -> lookup_type list * 'a
-
-val pp : Format.formatter -> t -> unit
 
 val set_resolver : t -> resolver -> t
 
@@ -140,26 +123,10 @@ val lookup_module :
   t ->
   Component.Module.t option
 
-val lookup_type :
-  Odoc_model.Paths_types.Identifier.type_ -> t -> Component.TypeDecl.t option
-
-val lookup_value :
-  Odoc_model.Paths_types.Identifier.value -> t -> Component.Value.t option
-
 val lookup_section_title :
   Odoc_model.Paths_types.Identifier.reference_label ->
   t ->
   Odoc_model.Comment.link_content option
-
-val lookup_class :
-  Odoc_model.Paths_types.Identifier.reference_class ->
-  t ->
-  Component.Class.t option
-
-val lookup_class_type :
-  Odoc_model.Paths_types.Identifier.class_type ->
-  t ->
-  Component.ClassType.t option
 
 val lookup_page : string -> t -> Odoc_model.Lang.Page.t option
 
@@ -190,6 +157,8 @@ val s_module : Component.Element.module_ scope
 val s_module_type : Component.Element.module_type scope
 
 val s_datatype : Component.Element.datatype scope
+
+val s_type : Component.Element.type_ scope
 
 val s_class : Component.Element.class_ scope
 

--- a/src/xref2/env.mli
+++ b/src/xref2/env.mli
@@ -122,6 +122,7 @@ val lookup_module :
   Odoc_model.Paths_types.Identifier.reference_module ->
   t ->
   Component.Module.t option
+(** Lookup a module by identifier or, if not found, lookup a root module. *)
 
 val lookup_section_title :
   Odoc_model.Paths_types.Identifier.reference_label ->

--- a/src/xref2/env.mli
+++ b/src/xref2/env.mli
@@ -21,11 +21,11 @@ type resolver = {
 }
 
 type lookup_type =
-  | Module of Odoc_model.Paths_types.Identifier.reference_module * bool
-  | ModuleType of Odoc_model.Paths_types.Identifier.module_type * bool
+  | Module of Odoc_model.Paths_types.Identifier.reference_module
+  | ModuleType of Odoc_model.Paths_types.Identifier.module_type
   | RootModule of string * [ `Forward | `Resolved of Digest.t ] option
   | ModuleByName of
-      string * Odoc_model.Paths_types.Identifier.reference_module option
+      string * Odoc_model.Paths_types.Identifier.reference_module
   | FragmentRoot of int
 
 val pp_lookup_type_list : Format.formatter -> lookup_type list -> unit

--- a/src/xref2/env.mli
+++ b/src/xref2/env.mli
@@ -192,6 +192,10 @@ type 'a scope constraint 'a = [< Component.Element.any ]
 val lookup_by_name : 'a scope -> string -> t -> 'a option
 (** Lookup an element in Env depending on the given [scope]. *)
 
+val lookup_by_id :
+  'a scope -> [< Odoc_model.Paths_types.Identifier.any ] -> t -> 'a option
+(** Like [lookup_by_name] but use an identifier as key. *)
+
 val s_any : Component.Element.any scope
 
 val s_signature : Component.Element.signature scope

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -380,8 +380,8 @@ and module_ : Env.t -> Module.t -> Module.t =
   if m.hidden then m
   else
     let t1 = Unix.gettimeofday () in
-    let m' =
-      match Env.lookup_module m.id env with
+    let `Module (_, m') =
+      match Env.(lookup_by_id s_module) m.id env with
       | Some m' -> m'
       | None ->
           kasprintf failwith "Failed to lookup module %a"
@@ -541,8 +541,8 @@ and functor_parameter_parameter :
   let sg_id = (a.id :> Id.Signature.t) in
   match
     let open Utils.ResultMonad in
-    Env.lookup_module a.id env' |> of_option ~error:"lookup"
-    >>= fun functor_arg ->
+    Env.(lookup_by_id s_module) a.id env' |> of_option ~error:"lookup"
+    >>= fun (`Module (_, functor_arg)) ->
     let env = Env.add_module_functor_args functor_arg a.id env' in
     match (a.expansion, functor_arg.type_) with
     | None, ModuleType expr -> (

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -470,13 +470,13 @@ and module_type : Env.t -> ModuleType.t -> ModuleType.t =
  fun env m ->
   let sg_id = (m.id :> Id.Signature.t) in
   let open ModuleType in
-  match Env.lookup_module_type m.id env with
+  match Env.(lookup_by_id s_module_type) m.id env with
   | None ->
       Lookup_failures.report "Failed to lookup module type %a"
         Component.Fmt.model_identifier
         (m.id :> Id.t);
       m
-  | Some m' ->
+  | Some (`ModuleType (_, m')) ->
       let env' = Env.add_module_type_functor_args m' m.id env in
       let expr' =
         match m.expr with

--- a/src/xref2/test.md
+++ b/src/xref2/test.md
@@ -366,51 +366,55 @@ by the module type `N`. However, `N` is not defined at the top level
 here, so it has a local identifier. We can see this by looking up module `M` from the environment:
 
 ```ocaml env=e1
-# let m = Env.lookup_module_type (`ModuleType (Common.root_with_name, Odoc_model.Names.ModuleTypeName.of_string "M")) env;;
-val m : Component.ModuleType.t option =
+# let m = Env.(lookup_by_id s_module_type) (`ModuleType (Common.root_with_name, Odoc_model.Names.ModuleTypeName.of_string "M")) env;;
+val m : Component.Element.module_type option =
   Some
-   {Odoc_xref2.Component.ModuleType.doc = [];
-    expr =
-     Some
-      (Odoc_xref2.Component.ModuleType.Signature
-        {Odoc_xref2.Component.Signature.items =
-          [Odoc_xref2.Component.Signature.ModuleType (`LModuleType (N, 1),
-            {Odoc_xref2.Component.Delayed.v =
-              Some
-               {Odoc_xref2.Component.ModuleType.doc = [];
-                expr =
-                 Some
-                  (Odoc_xref2.Component.ModuleType.Signature
-                    {Odoc_xref2.Component.Signature.items =
-                      [Odoc_xref2.Component.Signature.Type (`LType (t, 2),
-                        Odoc_model.Lang.Signature.Ordinary,
-                        {Odoc_xref2.Component.Delayed.v =
-                          Some
-                           {Odoc_xref2.Component.TypeDecl.doc = [];
-                            equation =
-                             {Odoc_xref2.Component.TypeDecl.Equation.params =
-                               [];
-                              private_ = false; manifest = None;
-                              constraints = []};
-                            representation = None};
-                         get = None})];
-                     removed = []});
-                expansion = Some Odoc_xref2.Component.Module.AlreadyASig};
-             get = None});
-           Odoc_xref2.Component.Signature.Module (`LModule (B, 0),
-            Odoc_model.Lang.Signature.Ordinary,
-            {Odoc_xref2.Component.Delayed.v =
-              Some
-               {Odoc_xref2.Component.Module.doc = [];
-                type_ =
-                 Odoc_xref2.Component.Module.ModuleType
-                  (Odoc_xref2.Component.ModuleType.Path
-                    (`Resolved (`Local (`LModuleType (N, 1)))));
-                canonical = None; hidden = false; display_type = None;
-                expansion = None};
-             get = None})];
-         removed = []});
-    expansion = Some Odoc_xref2.Component.Module.AlreadyASig}
+   (`ModuleType
+      (`ModuleType (`Root (Common.root, Root), M),
+       {Odoc_xref2.Component.ModuleType.doc = [];
+        expr =
+         Some
+          (Odoc_xref2.Component.ModuleType.Signature
+            {Odoc_xref2.Component.Signature.items =
+              [Odoc_xref2.Component.Signature.ModuleType
+                (`LModuleType (N, 1),
+                {Odoc_xref2.Component.Delayed.v =
+                  Some
+                   {Odoc_xref2.Component.ModuleType.doc = [];
+                    expr =
+                     Some
+                      (Odoc_xref2.Component.ModuleType.Signature
+                        {Odoc_xref2.Component.Signature.items =
+                          [Odoc_xref2.Component.Signature.Type
+                            (`LType (t, 2),
+                            Odoc_model.Lang.Signature.Ordinary,
+                            {Odoc_xref2.Component.Delayed.v =
+                              Some
+                               {Odoc_xref2.Component.TypeDecl.doc = [];
+                                equation =
+                                 {Odoc_xref2.Component.TypeDecl.Equation.params
+                                   = [];
+                                  private_ = false; manifest = None;
+                                  constraints = []};
+                                representation = None};
+                             get = None})];
+                         removed = []});
+                    expansion = Some Odoc_xref2.Component.Module.AlreadyASig};
+                 get = None});
+               Odoc_xref2.Component.Signature.Module (`LModule (B, 0),
+                Odoc_model.Lang.Signature.Ordinary,
+                {Odoc_xref2.Component.Delayed.v =
+                  Some
+                   {Odoc_xref2.Component.Module.doc = [];
+                    type_ =
+                     Odoc_xref2.Component.Module.ModuleType
+                      (Odoc_xref2.Component.ModuleType.Path
+                        (`Resolved (`Local (`LModuleType (N, 1)))));
+                    canonical = None; hidden = false; display_type = None;
+                    expansion = None};
+                 get = None})];
+             removed = []});
+        expansion = Some Odoc_xref2.Component.Module.AlreadyASig}))
 ```
 
 We can see here that module `B` has type `` Path (`Resolved (`Local (`LModuleType (N, 1)))) `` which refers to the module type defined just above it.

--- a/src/xref2/tools.ml
+++ b/src/xref2/tools.ml
@@ -166,7 +166,7 @@ let simplify_resolved_module_path :
   let path = Lang_of.(Path.resolved_module empty cpath) in
   let id = Odoc_model.Paths.Path.Resolved.Module.identifier path in
   let rec check_ident id =
-    match Env.lookup_module id env with
+    match Env.(lookup_by_id s_module) id env with
     | Some _ -> `Identifier id
     | None -> (
         match id with
@@ -425,7 +425,8 @@ and lookup_module :
       match path with
       | `Local lpath -> Error (`Local (env, lpath))
       | `Identifier i ->
-          of_option ~error:(`Lookup_failure i) (Env.lookup_module i env)
+          of_option ~error:(`Lookup_failure i) (Env.(lookup_by_id s_module) i env)
+          >>= fun (`Module (_, m)) -> Ok m
       | `Substituted x -> lookup_module ~mark_substituted env x
       | `Apply (functor_path, `Resolved argument_path) -> (
           match lookup_module ~mark_substituted env functor_path with
@@ -596,7 +597,8 @@ and resolve_module :
         | Unresolved func_path', Unresolved arg_path' ->
             Unresolved (`Apply (func_path', arg_path')) )
     | `Resolved (`Identifier i as resolved_path) as unresolved ->
-        of_option ~unresolved (Env.lookup_module i env) >>= fun m ->
+        of_option ~unresolved (Env.(lookup_by_id s_module) i env)
+        >>= fun (`Module (_, m)) ->
         return (process_module_path env ~add_canonical m resolved_path, m)
     | `Resolved r as unresolved -> (
         match lookup_module ~mark_substituted env r with

--- a/src/xref2/tools.ml
+++ b/src/xref2/tools.ml
@@ -681,14 +681,14 @@ and lookup_type :
         Ok
           (Find.Found (`T (List.assoc (TypeName.to_string name) core_types)) )
     | `Identifier (`Type _ as i) ->
-        of_option ~error:(`Lookup_failureT i) (Env.lookup_type i env)
-        >>= fun t -> Ok (Find.Found (`T t))
+        of_option ~error:(`Lookup_failureT i) (Env.(lookup_by_id s_type) i env)
+        >>= fun (`Type (_, t)) -> Ok (Find.Found (`T t))
     | `Identifier (`Class _ as i) ->
-        of_option ~error:(`Lookup_failureT i) (Env.lookup_class i env)
-        >>= fun t -> Ok (Find.Found (`C t))
+        of_option ~error:(`Lookup_failureT i) (Env.(lookup_by_id s_class) i env)
+        >>= fun (`Class (_, t)) -> Ok (Find.Found (`C t))
     | `Identifier (`ClassType _ as i) ->
-        of_option ~error:(`Lookup_failureT i) (Env.lookup_class_type i env)
-        >>= fun t -> Ok (Find.Found (`CT t))
+        of_option ~error:(`Lookup_failureT i) (Env.(lookup_by_id s_class_type) i env)
+        >>= fun (`ClassType (_, t)) -> Ok (Find.Found (`CT t))
     | `Substituted s ->
         lookup_type env s
     | `Type (p, id) ->

--- a/src/xref2/tools.ml
+++ b/src/xref2/tools.ml
@@ -535,7 +535,8 @@ and lookup_module_type :
     match path with
     | `Local _ -> Error (`LocalMT (env, path))
     | `Identifier i ->
-        of_option ~error:(`Lookup_failureMT i) (Env.lookup_module_type i env)
+        of_option ~error:(`Lookup_failureMT i) (Env.(lookup_by_id s_module_type) i env)
+        >>= fun (`ModuleType (_, mt)) -> Ok mt
     | `Substituted s
     | `SubstT (_, s) -> lookup_module_type ~mark_substituted env s
     | `ModuleType (parent, name) -> (


### PR DESCRIPTION
This PR removes most maps in `Env.t`, using a single map for every kinds.

Two generic lookup functions are added: `lookup_by_name` (which may have more than 1 result) and `lookup_by_id` (implemented on top of the first)
The `scope` type is used to restrict the search.

The first function is required for https://github.com/jonludlam/odoc/pull/27
The second function allows to remove other maps.

Removing other maps makes `Env.t` smaller and faster to update (which is often).

To ease implementation of https://github.com/jonludlam/odoc/pull/27, I'll try to remove the `Find` module in favor of `Env` which requires to make it faster.