### PR TITLE
Run the tests for the 'odoc' package only

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,3 @@
-(lang dune 2.7)
+(lang dune 2.8)
 (name odoc)
 (cram enable)

--- a/odoc-parser.opam
+++ b/odoc-parser.opam
@@ -26,7 +26,7 @@ depends: [
 ]
 
 build: [
- ["dune" "subst"] {pinned}
+  ["dune" "subst"] {pinned}
   [
     "dune"
     "build"

--- a/odoc.opam
+++ b/odoc.opam
@@ -27,7 +27,7 @@ depends: [
   "astring"
   "cmdliner"
   "cppo" {build}
-  "dune" {>= "2.7.0"}
+  "dune" {>= "2.8.0"}
   "fpath"
   "ocaml" {>= "4.02.0"}
   "result"
@@ -53,5 +53,15 @@ depends: [
 
 build: [
   ["dune" "subst"] {pinned}
-  ["dune" "build" "-p" name "-j" jobs]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
 ]

--- a/src/parser/test/dune
+++ b/src/parser/test/dune
@@ -1,5 +1,6 @@
 (library
  (name odoc_parser_test)
+ (package odoc)
  (inline_tests)
  (enabled_if
   (>= %{ocaml_version} 4.04.1))

--- a/test/html/dune
+++ b/test/html/dune
@@ -4,6 +4,7 @@
 
 (rule
  (alias runtest)
+ (package odoc)
  (action
   (run %{exe:test.exe}))
  (deps

--- a/test/integration/dune
+++ b/test/integration/dune
@@ -1,3 +1,3 @@
 (cram
- (deps
-  (package odoc)))
+ (package odoc)
+ (deps %{bin:odoc}))

--- a/test/latex/dune
+++ b/test/latex/dune
@@ -4,6 +4,7 @@
 
 (rule
  (alias runtest)
+ (package odoc)
  (action
   (run %{exe:test.exe}))
  (deps

--- a/test/man/dune
+++ b/test/man/dune
@@ -4,6 +4,7 @@
 
 (rule
  (alias runtest)
+ (package odoc)
  (action
   (run %{exe:test.exe}))
  (deps

--- a/test/model/dune
+++ b/test/model/dune
@@ -7,4 +7,5 @@
    (../xref2/compile.exe as compile))))
 
 (cram
+ (package odoc)
  (deps %{bin:odoc} %{bin:odoc_print} %{bin:compile}))

--- a/test/model/semantics/dune
+++ b/test/model/semantics/dune
@@ -1,8 +1,9 @@
 (library
  (name odoc_model_semantics_test)
+ (package odoc)
  (inline_tests)
  (enabled_if
   (>= %{ocaml_version} 4.04.1))
  (preprocess
   (pps ppx_expect))
- (libraries sexplib0 odoc_model type_desc_to_yojson))
+ (libraries sexplib0 odoc.model type_desc_to_yojson))

--- a/test/odoc_print/dune
+++ b/test/odoc_print/dune
@@ -1,9 +1,9 @@
 (library
  (name type_desc_to_yojson)
  (modules type_desc_to_yojson)
- (libraries odoc_model_desc yojson))
+ (libraries odoc.model_desc yojson))
 
 (executable
  (name odoc_print)
  (modules odoc_print)
- (libraries odoc_odoc cmdliner type_desc_to_yojson))
+ (libraries odoc.odoc cmdliner type_desc_to_yojson))

--- a/test/pages/dune
+++ b/test/pages/dune
@@ -4,6 +4,7 @@
    (../odoc_print/odoc_print.exe as odoc_print))))
 
 (cram
+ (package odoc)
  (enabled_if
   (>= %{ocaml_version} 4.04.1))
  (deps %{bin:odoc} %{bin:odoc_print}))

--- a/test/xref2/dune
+++ b/test/xref2/dune
@@ -10,11 +10,13 @@
    (./compile.exe as compile))))
 
 (cram
+ (package odoc)
  (deps %{bin:odoc} %{bin:odoc_print} %{bin:compile}))
 
 (subdir
  v407_and_above
  (cram
+  (package odoc)
   (deps %{bin:odoc} %{bin:odoc_print} %{bin:compile})
   (enabled_if
    (>= %{ocaml_version} 4.07.0))))
@@ -22,6 +24,7 @@
 (subdir
  v408_and_above
  (cram
+  (package odoc)
   (deps %{bin:odoc} %{bin:odoc_print} %{bin:compile})
   (enabled_if
    (>= %{ocaml_version} 4.08.0))))


### PR DESCRIPTION
- The parser package can't its tests run because of a circular dependency with ppx_expect.
- Run tests from Odoc's build script. This is the build script that Dune would have generated.

However:
- This increase the Dune version 2.8, which breaks esy